### PR TITLE
Make comments work when not starting on new line

### DIFF
--- a/syntaxes/sas.tmLanguage.json
+++ b/syntaxes/sas.tmLanguage.json
@@ -326,10 +326,10 @@
     },
     "line_comment_string": {
         "name": "comment.line.sas",
-        "begin": "(^[\\s%]*\\*)",
+        "begin": "(^|;)[\\s%]*(\\*)",
         "end": ";",
         "beginCaptures":{
-            "0":{
+            "1":{
                 "name": "punctuation.definition.comment"
             }
         },        


### PR DESCRIPTION
this PR fixes #11 
![image](https://user-images.githubusercontent.com/44071655/146480783-9a2b7b9e-624a-4414-8dec-966f57c3ce01.png)

unfortunately, this makes the `;` before the comment also comment colored but it is better than it was before